### PR TITLE
Quoted parser segments

### DIFF
--- a/Ash/Core/Handler.hs
+++ b/Ash/Core/Handler.hs
@@ -10,7 +10,6 @@
 
 module Core.Handler
   ( exceptionsIO
-  , installHandlers
   )
 where
 

--- a/Ash/Core/Handler.hs
+++ b/Ash/Core/Handler.hs
@@ -23,10 +23,6 @@ import           System.Exit                    ( ExitCode(..)
                                                 , exitSuccess
                                                 )
 import           System.IO                      ( stderr )
-import           System.Posix.Signals           ( installHandler
-                                                , Handler(Catch)
-                                                , keyboardSignal
-                                                )
 
 import qualified Data.Text.IO                  as I
 
@@ -34,6 +30,3 @@ import qualified Data.Text.IO                  as I
 exceptionsIO :: Text -> IOException -> IO ExitCode
 exceptionsIO message error =
   I.hPutStrLn stderr ("ash: " `append` message) >> return (ExitFailure 1)
-
-installHandlers :: IO Handler
-installHandlers = installHandler keyboardSignal (Catch exitSuccess) Nothing

--- a/Ash/Core/Parser.hs
+++ b/Ash/Core/Parser.hs
@@ -8,15 +8,42 @@
 
 module Core.Parser
   ( parse
+  , tokenize
   )
 where
 
 import           Core.Ash
 import qualified Data.Text                     as T
 
+-- TODO Allow for quoted strings to be a single token
 parse :: T.Text -> Command
-parse rawText = Command path args
+parse text = Command path args
  where
   path   = head tokens
   args   = tail tokens
-  tokens = T.words rawText
+  tokens = tokenize text
+
+tokenize :: T.Text -> [T.Text]
+tokenize text = map T.pack (splitq $ T.unpack text)
+
+-- https://stackoverflow.com/questions/4334897/functionally-split-a-string-by-whitespace-group-by-quotes
+splitq = outside [] . (' ' :)
+
+add c res = if null res then [[c]] else map (++ [c]) res
+
+outside res xs = case xs of
+  ' ' : ' '  : ys -> outside res $ ' ' : ys
+  ' ' : '\'' : ys -> res ++ inside [] ys
+  ' ' : '\"' : ys -> res ++ inside [] ys
+  ' '        : ys -> res ++ outside [] ys
+  c          : ys -> outside (add c res) ys
+  _               -> res
+
+inside res xs = case xs of
+  ' '  : ' ' : ys -> inside res $ ' ' : ys
+  '\'' : ' ' : ys -> res ++ outside [] (' ' : ys)
+  '\"' : ' ' : ys -> res ++ outside [] (' ' : ys)
+  '\''       : [] -> res
+  '\"'       : [] -> res
+  c          : ys -> inside (add c res) ys
+  _               -> res

--- a/test/Core/ExecutorSpec.hs
+++ b/test/Core/ExecutorSpec.hs
@@ -11,7 +11,7 @@
 module Core.ExecutorSpec where
 
 import           Core.Executor
-import Core.Ash
+import           Core.Ash
 import qualified Data.Text                     as T
 import           System.Exit                    ( ExitCode(..) )
 import           Test.Hspec
@@ -35,4 +35,3 @@ spec = do
     $ do
         exitStatus <- execute $ Command "ls" ["--notACommand"]
         exitStatus `shouldBe` ExitFailure 2
-

--- a/test/Core/ParserSpec.hs
+++ b/test/Core/ParserSpec.hs
@@ -19,12 +19,27 @@ main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec =
+spec = do
   describe "parse"
     $          context "when given a string"
-    $          it "returns a Command structure"
+    $          it "returns a list of tokens seperated by whitespace"
     $          parse "ls -a -t"
     `shouldBe` Command "ls" ["-a", "-t"]
 
+  describe "parse"
+    $          context "when given a string with double quoted segments"
+    $          it "returns a list of tokens with quoted segments grouped"
+    $          parse "git commit -m \"Some new commit\""
+    `shouldBe` Command "git" ["commit", "-m", "Some new commit"]
 
+  describe "parse"
+    $          context "when given a string with single quoted segments"
+    $          it "returns a list of tokens with quoted segments grouped"
+    $          parse "git commit -m 'Some new commit'"
+    `shouldBe` Command "git" ["commit", "-m", "Some new commit"]
 
+  describe "parse"
+    $          context "when given a string with variable assignment"
+    $          it "keeps the variable and assignment together"
+    $          parse "export ASH=\"home/user/.config\""
+    `shouldBe` Command "export" ["ASH=\"home/user/.config\""]


### PR DESCRIPTION
Updates the parser module to allow for quoted segments in the command. I.E. the command:
```bash
git commit -m "some commit" 
```
will be parsed into `["git", "commit", "-m", "some commit"] instead of ["git", "commit", "-m", "some", "commit"]
